### PR TITLE
[PHP] Add xp-forge/json-patch

### DIFF
--- a/implementations.md
+++ b/implementations.md
@@ -98,6 +98,13 @@ github: https://github.com/raphaelstolt/php-jsonpatch
 packagist: https://packagist.org/packages/php-jsonpatch/php-jsonpatch
 supported: RFC6902
 
+xp-forge/json-patch
+-------------------
+
+github: https://github.com/xp-forge/json-patch
+packagist: https://packagist.org/packages/xp-forge/json-patch
+supported: RFC6902
+
 JAVA
 ====
 

--- a/index.md
+++ b/index.md
@@ -120,6 +120,7 @@ If we're missing a library please let us know (see below)!
 
 - [json-patch-php](https://github.com/mikemccabe/json-patch-php)
 - [php-jsonpatch/php-jsonpatch](https://github.com/raphaelstolt/php-jsonpatch)
+- [xp-forge/json-patch](https://github.com/xp-forge/json-patch)
 
 ## Ruby
 


### PR DESCRIPTION
This pull request adds a link to the [xp-forge/json-patch](https://github.com/xp-forge/json-patch) library to the implementations markdown file.

This library requires PHP 5.6 or HHVM 3.5 upwards.
