### PR TITLE
Remove JSON-Gui from Tools

### DIFF
--- a/index.md
+++ b/index.md
@@ -190,7 +190,6 @@ A collection of conformance tests for JSON Patch are maintained on Github:
 
 # Tools
 
-- [JSON-Gui](https://json-gui.site)
 - [json-patch-builder-online](https://json-patch-builder-online.github.io)
 - [json-lab-patcher](http://helmet.kafuka.org/sbmods/json/#patcher)
 - [JSONBuddy editor](https://www.json-buddy.com)


### PR DESCRIPTION
It seems https://json-gui.site returns an https error, and that the domain name is for sale.