### PR TITLE
Manatee.Json was replaced by json-everything

### DIFF
--- a/index.md
+++ b/index.md
@@ -164,7 +164,7 @@ If we're missing a library please let us know (see below)!
 - [JsonPatch](https://github.com/myquay/JsonPatch) (Adds JSON Patch support to ASP.NET Web API)
 - [Starcounter](https://starcounter.io) (In-memory Application Engine, uses JSON Patch with OT for client-server sync)
 - [Nancy.JsonPatch](https://github.com/DSaunders/Nancy.JsonPatch) (Adds JSON Patch support to NancyFX)
-- [Manatee.Json](http://github.com/gregsdennis/Manatee.Json) (JSON-everything, including JSON Patch)
+- [JsonPatch.Net](http://github.com/gregsdennis/json-everything) (JSON Patch support for System.Text.Json)
 
 ## Go
 


### PR DESCRIPTION
I have sunsetted Manate.Json.  Its replacement is the json-everything project.  Same idea, but using System.Text.Json as the parser instead of one I built.