### PR TITLE
remove duplicate tool and added tool extendsclass

### DIFF
--- a/index.md
+++ b/index.md
@@ -214,7 +214,7 @@ A collection of conformance tests for JSON Patch are maintained on Github:
 - [json-lab-patcher](http://helmet.kafuka.org/sbmods/json/#patcher)
 - [JSONBuddy editor](https://www.json-buddy.com)
 - [jsonpatch.me](https://jsonpatch.me)
-- [json-patch-builder-online](https://json-patch-builder-online.github.io)
+- [ExtendsClass](https://extendsclass.com/json-patch.html)
 
 # JSON Schema
 


### PR DESCRIPTION
Hello, I removed, https://json-patch-builder-online.github.io, there were two links to this tool. 
I added Extendsclass (I am the founder), a json patch generator.