### PR TITLE
Add entry for https://bsonpatch.github.io/bsonpatch

### DIFF
--- a/index.md
+++ b/index.md
@@ -154,7 +154,8 @@ If we're missing a library please let us know (see below)!
 - [simple-json-patch](https://github.com/egerardus/simple-json-patch)
 - [zjsonpatch](https://github.com/flipkart-incubator/zjsonpatch)
 - [json-patch](https://github.com/fge/json-patch)
-- [bsonpatch](https://github.com/ebay/bsonpatch) (port of **zjsonpatch** that uses [BSON](https://en.wikipedia.org/wiki/BSON) as document model)
+- [bsonpatch](https://bsonpatch.github.io/bsonpatch) (port of [zjsonpatch](https://github.com/flipkart-incubator/zjsonpatch) that uses [BSON](https://en.wikipedia.org/wiki/BSON) as document model)
+- [bsonpatch](https://github.com/ebay/bsonpatch) (older, not current supported, version of [bsonpatch](https://bsonpatch.github.io/bsonpatch))
 
 ## Kotlin
 


### PR DESCRIPTION
No one is actively maintaining https://github.com/ebay/bsonpatch, so I forked it, repackaged, and brought it up to date with https://github.com/flipkart-incubator/zjsonpatch